### PR TITLE
Update youtube-dl dependancy to version 2019.5.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mock==2.0.0
 pbr==5.1.2
 pycaption==1.0.1
 six==1.12.0
-youtube-dl==2019.2.18
+youtube-dl==2019.5.20


### PR DESCRIPTION
Resolves "token parameter not in video info for unknown reason" issue reported [here](https://github.com/ytdl-org/youtube-dl/issues/20758). No other changes were necessary to include the updated youtube-dl.